### PR TITLE
Display hex colors in ARGB format + fix for hex format with alpha value

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Display resources from linked and parent style guides.
 
 QML name space of style guide. A prefix to color names etc.
 
+#### ARGB hex color format
+
+Display hex colors in ARGB format with the alpha value as the first tuple (instead of the default Zeplin format with alpha last)
+
 #### Text i18n option
 
 If enabled, will wrap text into `qsTr('text')` or `qsTrId('text-id')`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "qml-extension",
+  "name": "zeplin-qml-extension",
   "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,12 @@
         "default": ""
       },
       {
+        "name": "Display hex colors in ARGB format",
+        "type": "switch",
+        "id": "useAlphaRgbHex",
+        "default": true
+      },
+      {
         "name": "Text i18n Options",
         "type": "picker",
         "id": "translationFunction",

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@ export const OPTION_NAMES = {
   RESIZE_FUNCTION: "resizeFunction",
   USE_LINKED_STYLEGUIDES: "useLinkedStyleguides",
   STYLE_GUIDE_NAMESPACE: "styleGuideNamespace",
+  HEX_ARGB: "useAlphaRgbHex",
   TRANSLATION_FUNCTION: "translationFunction",
 };
 

--- a/src/generators/index.js
+++ b/src/generators/index.js
@@ -122,7 +122,7 @@ ${attrs.join('\n')}\n}`
 
 const parseColor = (extensionColor) => {
   const color = Color.fromRGBA(extensionColor);
-  return color.toStyleValue('hex', {})
+  return color.toStyleValue({ colorFormat: 'hex'})
 };
 
 const getColorTable = (colorList) => {

--- a/src/generators/index.js
+++ b/src/generators/index.js
@@ -13,7 +13,7 @@ export class QmlLayerGenerator {
   }
 
   getColorValue(extensionColor) {
-    const hexColor = parseColor(extensionColor);
+    const hexColor = parseColor(extensionColor, this.options.useAlphaRgbHex);
     if (!this.options.useLinkedStyleguides || ! (hexColor in this.colorTable)) {
       return `"${hexColor}"`
     }
@@ -120,9 +120,25 @@ ${attrs.join('\n')}\n}`
 
 }
 
-const parseColor = (extensionColor) => {
+
+function decToHex(c) {
+  var hex = c.toString(16);
+  return hex.length === 1 ? "0" + hex : hex;
+}
+
+function toHexAlphaString(color) {
+  let hexCode = decToHex(color.r) + decToHex(color.g) + decToHex(color.b);
+
+  if (color.a < 1) {
+      hexCode = decToHex(Math.round(color.a * 255)) + hexCode;
+  }
+
+  return `#${hexCode}`;
+}
+
+const parseColor = (extensionColor, useAlphaRgbHex = false) => {
   const color = Color.fromRGBA(extensionColor);
-  return color.toStyleValue({ colorFormat: 'hex'})
+  return useAlphaRgbHex ? toHexAlphaString(extensionColor) : color.toStyleValue({ colorFormat: 'hex'})
 };
 
 const getColorTable = (colorList) => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ function layer(context, selectedLayer) {
     useLinkedStyleguides: context.getOption(OPTION_NAMES.USE_LINKED_STYLEGUIDES),
     resizeFunction: context.getOption(OPTION_NAMES.RESIZE_FUNCTION),
     styleGuideNamespace: context.getOption(OPTION_NAMES.STYLE_GUIDE_NAMESPACE),
+    useAlphaRgbHex: context.getOption(OPTION_NAMES.HEX_ARGB),
     translationFunction: context.getOption(OPTION_NAMES.TRANSLATION_FUNCTION),
 
   };


### PR DESCRIPTION
We have tested the extension and found out that **color values with alpha** will _always_ be displayed as `rgba(...)`, because of the way the color used to be converted (:
```javascript
color.toStyleValue({ colorFormat: 'hex'}); // use of object with key 'colorFormat' instead of string 'hex'
```

Additionally, the **hex format** _with alpha channel_ in QML has the **alpha value as first tuple** instead of last (as Zeplin seems to convert it by default).

- `rgba(0, 0, 0, 0.8)`
- `#000000cc` (RGBA as Zeplin default conversion)
- `#cc000000` (ARGB as in QML)

I have added this change as default setting with the option to disable it. This shouldn't be a problem as the current display does not show the RGBA hex format.

> **One addition:** Zeplin uses [Math.trunc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc) to cut-off the fractional digits. It is more common to use `Math.round` for the conversion. This may lead to different values, i.e. **alpha 30%** is `76.5` which can be `#4c` (trunc) or `#4d` (round).
